### PR TITLE
设置XCTESTWD framework使用XCTESTWD_PORT

### DIFF
--- a/XCTestWD/XCTestWD.xcodeproj/project.pbxproj
+++ b/XCTestWD/XCTestWD.xcodeproj/project.pbxproj
@@ -1034,7 +1034,7 @@
 					"$(SDKROOT)/../../Library/Frameworks",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=8001";
+				GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=$(XCTESTWD_PORT)";
 				HEADER_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(SRCROOT)/",
@@ -1087,7 +1087,7 @@
 					"$(SDKROOT)/../../Library/Frameworks",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=8001";
+				GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=$(XCTESTWD_PORT)";
 				HEADER_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(SRCROOT)/",


### PR DESCRIPTION
修改使用xcodebuild 设置XCTESTWD_PORT时不起作用的问题，对XCTESTWD framework设置GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=$(XCTESTWD_PORT)"